### PR TITLE
Add job to publish to GPR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           name: out
           path: .
+      - run: ls -la
       - uses: actions/setup-node@v2
         with:
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,23 @@ name: build
 on: [push, pull_request]
 
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.gitversion.outputs.fullSemVer }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: gittools/actions/gitversion/setup@v0.9.11
+        with:
+          versionSpec: '5.x'
+      - uses: gittools/actions/gitversion/execute@v0.9.11
+        id: gitversion
+        with:
+          useConfigFile: true
+          configFilePath: .github/gitversion.yml
+
   build:
     strategy:
       matrix:
@@ -52,7 +69,7 @@ jobs:
           path: '*.vsix'
 
   publish-gpr:
-    needs: build
+    needs: [version, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -65,6 +82,8 @@ jobs:
           registry-url: https://npm.pkg.github.com
       - name: npm scope
         run: npm init -y --scope ${{github.repository_owner}}
+      - name: npm version
+        run: npm version --no-git-tag-version ${{needs.version.outputs.version}}
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,19 @@ jobs:
         with:
           name: vscode-remark.vsix
           path: '*.vsix'
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: out
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: https://npm.pkg.github.com
+      - name: npm scope
+        run: npm init -y --scope ${{github.repository_owner}}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.gitversion.outputs.fullSemVer }}
+      version: ${{steps.gitversion.outputs.fullSemVer}}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -38,8 +38,10 @@ jobs:
       - run: npm run build
       - uses: actions/upload-artifact@v2
         with:
-          name: out
-          path: out
+          name: vscode-remark
+          path: |
+            out
+            package*.json
       - name: test
         uses: GabrielBB/xvfb-action@v1.6
         env:
@@ -74,9 +76,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: out
-          path: .
-      - run: ls -la
+          name: vscode-remark
       - uses: actions/setup-node@v2
         with:
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: out
+          path: .
       - uses: actions/setup-node@v2
         with:
           registry-url: https://npm.pkg.github.com


### PR DESCRIPTION
Add a GitHub Actions job to publish the NPM package to the GitHub Package Registry.

<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

As per https://github.com/actions/setup-node/issues/243#issuecomment-995742416, an ephemeral scope can be set with `npm init -y --scope ${{ github.repository_owner }}` before `npm publish` is executed. This PR is an attempt to implement this.

<!--do not edit: pr-->
