### PR TITLE
Remove code coverage integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,8 @@ jobs:
           path: out
       - name: test
         uses: GabrielBB/xvfb-action@v1.6
-        env:
-          COVERAGE: true
         with:
           run: npm test
-      - uses: codecov/codecov-action@v2
 
   package:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,3 @@ out/
 
 # Visual Studio Code Extension package
 *.vsix
-
-coverage
-.nyc_output

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # remark for Visual Studio Code
 
 [![Build][build-badge]][build]
-[![Coverage][coverage-badge]][coverage]
 [![Downloads][downloads-badge]][marketplace]
 [![Sponsors][sponsors-badge]][collective]
 [![Backers][backers-badge]][collective]
@@ -146,10 +145,6 @@ abide by its terms.
 [build-badge]: https://github.com/remarkjs/vscode-remark/workflows/main/badge.svg
 
 [build]: https://github.com/remarkjs/vscode-remark/actions
-
-[coverage-badge]: https://img.shields.io/codecov/c/github/remarkjs/vscode-remark.svg
-
-[coverage]: https://codecov.io/github/remarkjs/vscode-remark
 
 [downloads-badge]: https://img.shields.io/visual-studio-marketplace/d/unifiedjs.vscode-remark
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Currently code coverage is broken. Also the source code is a couple of sequential statements without branches, so there isn’t much to cover.

I did try to integrate c8, but couldn’t get it to work. It’s confusing, because the tests run in electron.

<!--do not edit: pr-->
