### PR TITLE
Fix to mark `.remarkignore` as filename, not extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "languages": [
       {
         "id": "ignore",
-        "extensions": [
+        "filenames": [
           ".remarkignore"
         ]
       },


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

`.remarkignore` is a filename, not a file extension.

<!--do not edit: pr-->
