### PR TITLE
Update publish workflow

### DIFF
--- a/.github/gitversion.yml
+++ b/.github/gitversion.yml
@@ -1,1 +1,0 @@
-mode: ContinuousDeployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - run: npx vsce package
       - run: npx vsce publish --packagePath *.vsix
         env:
-          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+          VSCE_PAT: ${{secrets.VSCE_TOKEN}}
       - run: npx ovsx publish --packagePath *.vsix
         env:
-          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+          OVSX_PAT: ${{secrets.OPEN_VSX_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,16 +13,10 @@ jobs:
         with:
           node-version: 16
       - run: npm install
-      - run: npm run build
-      - name: ovsx publish
-        uses: HaaLeo/publish-vscode-extension@v1
-        id: ovsx_publish
-        with:
-          pat: ${{secrets.OPEN_VSX_TOKEN}}
-      - name: vsce publish
-        uses: HaaLeo/publish-vscode-extension@v1
-        with:
-          pat: ${{secrets.VSCE_TOKEN}}
-          registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{steps.ovsx_publish.outputs.vsixPath}}
-          packagePath: ''
+      - run: npx vsce package
+      - run: npx vsce publish --packagePath *.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_TOKEN }}
+      - run: npx ovsx publish --packagePath *.vsix
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,25 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          fetch-depth: 0
-      - uses: gittools/actions/gitversion/setup@v0.9.13
-        with:
-          versionSpec: '5.x'
-      - uses: gittools/actions/gitversion/execute@v0.9.13
-        id: gitversion
-        with:
-          useConfigFile: true
-          configFilePath: .github/gitversion.yml
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-npm
-        with:
-          path: ~/.npm
-          key: ${{runner.os}}-build-${{env.cache-name}}-${{hashFiles('**/package-lock.json')}}
-          restore-keys: ${{runner.os}}-build-${{env.cache-name}}-
-      - name: npm version
-        run: npm version --no-git-tag-version ${{steps.gitversion.outputs.fullSemVer}}
+          node-version: 16
       - run: npm install
       - run: npm run build
       - name: ovsx publish
@@ -42,14 +26,3 @@ jobs:
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{steps.ovsx_publish.outputs.vsixPath}}
           packagePath: ''
-      - uses: actions/upload-artifact@v3
-        with:
-          name: vscode-remark.vsix
-          path: ${{steps.ovsx_publish.outputs.vsixPath}}
-      - name: upload vsix to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{secrets.GITHUB_TOKEN}}
-          file: ${{steps.ovsx_publish.outputs.vsixPath}}
-          asset_name: vscode-remark.vsix
-          tag: ${{github.ref}}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/vscode": "^1.0.0",
     "@vscode/test-electron": "^2.0.0",
     "esbuild": "^0.14.0",
+    "ovsx": "^0.5.0",
     "prettier": "^2.0.0",
     "remark-cli": "^11.0.0",
     "remark-language-server": "^2.0.0",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The `actions/setup-node` action was added. and `gitversion` related configuration removed.

I left in `HaaLeo/publish-vscode-extension`, but I don’t see any advantage over using the official `vsce` and `ovsx` tools.

Once this is merged, I think we’re ready for a version 2.0 release.

<!--do not edit: pr-->