### PR TITLE
Fix missing `await` in test

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert')
 const fs = require('node:fs/promises')
 const path = require('node:path')
 
-const {commands, extensions, Uri, window, workspace} = require('vscode')
+const {commands, extensions, window, workspace} = require('vscode')
 
 module.exports.run = async () => {
   const filePath = path.join(__dirname, 'test.md')
@@ -10,9 +10,8 @@ module.exports.run = async () => {
     const ext = extensions.getExtension('unifiedjs.vscode-remark')
     await ext?.activate()
 
-    fs.writeFile(filePath, '- remark\n- lsp\n- vscode\n')
-    const uri = Uri.file(filePath)
-    const doc = await workspace.openTextDocument(uri)
+    await fs.writeFile(filePath, '- remark\n- lsp\n- vscode\n')
+    const doc = await workspace.openTextDocument(filePath)
     await window.showTextDocument(doc)
     await commands.executeCommand('editor.action.formatDocument')
 


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The promise returned by `fs.writeFile` wasn’t awaited.

Also `workspace.openTectDocument` accepts a string URI,

<!--do not edit: pr-->
