### PR TITLE
Rename `package-json-schema.json` to `package.schema.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       },
       {
         "fileMatch": "package.json",
-        "url": "./package-json-schema.json"
+        "url": "./package.schema.json"
       }
     ],
     "languages": [

--- a/package.schema.json
+++ b/package.schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema",
   "properties": {
     "remarkConfig": {
       "description": "remark configuration",


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

The name `package-json-schema.json` was copied from another VSCode extension. However, the filename `*.schema.json` is more commonly used to store JSON schemas.

This file name is also mapped to the JSON schema of a JSON schema by VSCode by default.

<!--do not edit: pr-->
