### PR TITLE
Remove generated extension metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,11 +128,5 @@
         ]
       }
     ]
-  },
-  "__metadata": {
-    "id": "fb2da10c-d116-420d-bf07-97f9208e23a6",
-    "publisherDisplayName": "unified",
-    "publisherId": "207bcd0f-c1b5-4dc9-ab76-47615c59238d",
-    "isPreReleaseVersion": false
   }
 }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This was generated by VSCode when running tests. This is a bug that has been fixed upstream for the upcoming version of VSCode.

See https://github.com/microsoft/vscode/issues/148975

<!--do not edit: pr-->
