### PR TITLE
Fixing test errors

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -12,6 +12,11 @@ import {
  * @param {ExtensionContext} context
  */
 export async function activate(context) {
+  const remarkConfigWatcher = workspace.createFileSystemWatcher(
+    '**/.remark{ignore,rc,rc.cjs,rc.js,rc.json,rc.mjs,rc.yaml,rc.yml}'
+  )
+  const packageJsonWatcher = workspace.createFileSystemWatcher('**/package.json')
+
   const client = new LanguageClient(
     'remark',
     {
@@ -21,12 +26,7 @@ export async function activate(context) {
     {
       documentSelector: [{scheme: 'file', language: 'markdown'}],
       synchronize: {
-        fileEvents: [
-          workspace.createFileSystemWatcher(
-            '**/.remark{ignore,rc,rc.cjs,rc.js,rc.json,rc.mjs,rc.yaml,rc.yml}'
-          ),
-          workspace.createFileSystemWatcher('**/package.json')
-        ]
+        fileEvents: [remarkConfigWatcher, packageJsonWatcher]
       }
     }
   )
@@ -35,7 +35,9 @@ export async function activate(context) {
 
   context.subscriptions.push(
     client,
-    commands.registerCommand('remark.restart', restart)
+    commands.registerCommand('remark.restart', restart),
+    remarkConfigWatcher,
+    packageJsonWatcher
   )
 
   return client

--- a/src/extension.js
+++ b/src/extension.js
@@ -31,14 +31,14 @@ export async function activate(context) {
     }
   )
 
-  await client.start()
-
   context.subscriptions.push(
     client,
     commands.registerCommand('remark.restart', restart),
     remarkConfigWatcher,
     packageJsonWatcher
   )
+
+  await client.start()
 
   return client
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,7 @@ before(async () => {
 })
 
 afterEach(async () => {
+  await commands.executeCommand('workbench.action.closeAllEditors')
   await fs.rm(filePath, {force: true})
 })
 


### PR DESCRIPTION


<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

I asked Claude to fix the test issues, apparently there was a race condition of sorts in disposables

---

The two FileSystemWatcher objects created for synchronize.fileEvents were
created inline inside the LanguageClient constructor options but never added
to context.subscriptions. This left their lifecycle unmanaged: when the
client restarted or the extension deactivated, the watchers could fire
events into already-disposed internal DisposableStores, producing the
"Trying to add a disposable to a DisposableStore that has already been
disposed of" errors seen in tests.

Extract the watchers to named variables and push them into
context.subscriptions after the client, so VS Code disposes them in the
correct order (client first, then watchers).

https://claude.ai/code/session_01WFwY3AwmRDMMvQTemKCE4S

<!--do not edit: pr-->
